### PR TITLE
Allow initialize method to take args

### DIFF
--- a/lib/memcache_mock.rb
+++ b/lib/memcache_mock.rb
@@ -1,7 +1,7 @@
 require "memcache_mock/version"
 
 class MemcacheMock
-  def initialize( )
+  def initialize( *nodes )
     @values = {}
   end
 

--- a/test/memcache_mock_test.rb
+++ b/test/memcache_mock_test.rb
@@ -8,6 +8,7 @@ class MemcacheMockTest < Test::Unit::TestCase
   def test_initialize
     assert( @cache.is_a? MemcacheMock )
     assert_equal( {}, @cache.instance_variable_get( :@values ) )
+    assert_equal( -1, lambda(&MemcacheMock.method(:new)).arity)
   end
 
   def test_incr_when_key_not_exists


### PR DESCRIPTION
the Dalli client can take multiple memcache nodes in its initialize method.  In order to swap this in seamlessly for the Dalli client.
